### PR TITLE
fix: Modification couleur de type de contact

### DIFF
--- a/htdocs/avoloicustomtypes/class/api_avoloicustomtypes.class.php
+++ b/htdocs/avoloicustomtypes/class/api_avoloicustomtypes.class.php
@@ -69,7 +69,13 @@ class AvoloiCustomTypes extends DolibarrApi
 	public function contacttypecolor($id, $color_code = "737373") {
 		global $conf, $langs, $user;
 
-		// print "COLOR : ".$color_code."<br>";
+		if ($color_code === "") {
+			$color_code = "737373";
+		}
+
+		if (!ctype_xdigit($color_code)) {
+			throw new RestException(400, "$color_code is not a hexadecimal digit");
+		}
 
 		$sql = "UPDATE `avo_custom_contact_type`";
 		$sql.= " SET `color`='$color_code',";


### PR DESCRIPTION
Le bug était que si color_code était une chaîne vide, une chaîne vide était enregistrée en DB.
J'ai ajouté une vérification sur la valeur de color_code pour vérifier que ça ne soit pas une chaîne vide.

De plus j'ai ajouté une vérification sur color_code vérifiant s'il s'agit bien d'une valeur hexadécimale.
Si color_code n'est pas une valeur hexadécimale, une erreur est renvoyée.