### PR TITLE
fix: Récupération des types de contacts

### DIFF
--- a/htdocs/avoloicustomtypes/class/api_avoloicustomtypes.class.php
+++ b/htdocs/avoloicustomtypes/class/api_avoloicustomtypes.class.php
@@ -99,7 +99,7 @@ class AvoloiCustomTypes extends DolibarrApi
 	 * @throws 404
 	 * @throws 200
 	 *
-	 * @url GET /contacttypes
+	 * @url GET /getallcontacttype
 	 */
 	public function getcontacttypes() {
 		global $conf, $langs, $user;


### PR DESCRIPTION
Réallignement du nom de la route avec la spécification.
"/contacttypes" devient "/getallcontacttype"